### PR TITLE
{nei}r4.1.3 fix

### DIFF
--- a/R/mod_diff_abund.R
+++ b/R/mod_diff_abund.R
@@ -438,7 +438,8 @@ mod_diff_abund_server <- function(input, output, session, improxy){
 
   # deseq contrasts in results
   contrast_avail <- reactive({
-    out <- DESeq2::resultsNames(dds_obj())
+    out <- dds_obj()
+    out <- DESeq2::resultsNames(out)
     out <- out[2:length(out)]
     rev(out)
   })

--- a/R/mod_diff_abund.R
+++ b/R/mod_diff_abund.R
@@ -447,8 +447,12 @@ mod_diff_abund_server <- function(input, output, session, improxy){
     req(input$variable)
     cat('Model design:\n')
     print(paste(as.character(deseq_design()), collapse=''))
-    cat('\nModel summary:\n')
-    print(summary(dds_obj()))
+
+    ## Nick Ilott: I have removed this summary
+    ## section until I find out how to reproduce
+    ## the output without using summary()
+    #cat('\nModel summary:\n')
+    #print(summary(dds_obj()))
     cat('\nEstimated effects of the Model"\n')
     print(contrast_avail())
   })

--- a/R/mod_ov_permanova.R
+++ b/R/mod_ov_permanova.R
@@ -24,20 +24,27 @@ mod_ov_permanova_ui <- function(id){
         uiOutput(ns('stratify_ui')),
         uiOutput(ns('permanova_dist_ui')),
         br(), br(),
-        actionButton(ns('permanova_calculate'), 'Calculate PERMANOVA')
+        actionButton(ns('permanova_calculate'), 'Calculate PERMANOVA'),
+        
+        ## Nick Ilott: R4.1.3 I was having issues with the hidden
+        ## div so have put this in here. It's not pretty but
+        ## works :)      
+        br(), br(),
+        h4('PERMANOVA Results'),
+        DT::dataTableOutput(ns('permanova_summary'))
       )
-    ),
-    hidden(div(ns('permanova_result_div'),
-      fluidRow(
-        column(
-          width = 12,
-          h3('PERMANOVA Results'),
-          DT::dataTableOutput(ns('permanova_summary'))
-        )
-      )
-    ))
+    )
   )
-}
+} 
+
+## Nick Ilott: Keeping this here commented out so 
+## is easy to re-implement if required
+#    hidden(div(ns('permanova_result_div'),
+#      fluidRow(
+#        column(
+#          width = 12,
+#          h3('PERMANOVA Results'),
+#          DT::dataTableOutput(ns('permanova_summary'))
 
 #' ov_permanova Server Function
 #'
@@ -49,10 +56,11 @@ mod_ov_permanova_server <- function(input, output, session, bridge){
   # bridge$filtered$met # metadata table
   # bridge$filtered$tax # taxonomy table
 
+  ## Nick Ilott: Keeping here in case we decide to re-implement
   # render input ui-------------------------------------------------------------
-  observeEvent(input$permanova_calculate, {
-    show('permanova_result_div')
-  })
+  #  observeEvent(input$permanova_calculate, {
+  #    show('permanova_result_div')
+  #  })
 
   output$formula_ui <- renderUI({
     bucket_list(
@@ -135,21 +143,22 @@ mod_ov_permanova_server <- function(input, output, session, bridge){
                     method = input$permanova_dist,
                     permutations = perm)
     }
-    out$aov.tab <- suppressWarnings(broom::tidy(out))
-    out
+    ## Nick Ilott: I think this is all we need and
+    ## stops errors with calling as.data.frame on
+    ## reactive objects later on
+    as.data.frame(suppressWarnings(broom::tidy(out)))
   })
 
   # permanova result summary
-  output$permanova_summary <- DT::renderDataTable(server = FALSE, {
-    out <- as.data.frame(fit()$aov.tab)
-    DT::datatable(out, rownames = FALSE)
+  output$permanova_summary <- DT::renderDataTable({
+    fit()
   })
 
   cross_module <- reactiveValues()
   observe({
     cross_module$output <- list(
       permanova_formula = formula_preview(),
-      permanova_summary = as.data.frame(fit()$aov.tab)
+      permanova_summary = fit())
     )
   })
 

--- a/R/mod_ov_permanova.R
+++ b/R/mod_ov_permanova.R
@@ -158,7 +158,7 @@ mod_ov_permanova_server <- function(input, output, session, bridge){
   observe({
     cross_module$output <- list(
       permanova_formula = formula_preview(),
-      permanova_summary = fit())
+      permanova_summary = fit()
     )
   })
 


### PR DESCRIPTION
I'm merging this into main now. It looks like that some updates to R/RShiny in R4.1.3 and/or shiny > 1.5 have caused some issues in how reactive objects can be used in terms of calling functions on them. i.e. the app crashed when summary() was called on a reactive e.g. summary(summary_pcx()). I have worked around this by avoiding summary calls in most places or in other cases where similar things happened I assigned the reacive to a new variable before the function call. There shouldn't be any issues if the development version of the app is run on older versions of R.